### PR TITLE
Update ssr system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `@todovue/tv-relative-time` will be documented in this fi
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
+## [1.0.2] - 2025-10-17
+### 🛠️ Changed
+- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
+- CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-relative-time.css` file optimized for SSR/Nuxt.
+- Changed node-version to workflows release.yml to 20.
+
+### ✨ Added
+- Plugin installation support: `app.use(TvRelativeTime)` or `app.use(TvRelativeTimePlugin)`.
+- Explicit export of the style file: `import '@todovue/tv-relative-time/style.css'`.
+- Documentation for usage in SSR and Nuxt 3 applications.
+
 ## [1.1.0] - 2025-05-06
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@todovue/tv-relative-time` will be documented in this fi
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
-## [1.0.2] - 2025-10-17
+## [1.1.1] - 2025-10-18
 ### 🛠️ Changed
 - The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
 - CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-relative-time.css` file optimized for SSR/Nuxt.
@@ -44,5 +44,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+[1.1.1]: https://github.com/TODOvue/tv-relative-time/pull/3/files
 [1.1.0]: https://github.com/TODOvue/tv-relative-time/pull/2/files
 [1.0.0]: https://github.com/TODOvue/tv-relative-time/pull/1/files

--- a/README.md
+++ b/README.md
@@ -1,72 +1,378 @@
 <p align="center"><img width="150" src="https://firebasestorage.googleapis.com/v0/b/todovue-blog.appspot.com/o/logo.png?alt=media&token=d8eb592f-e4a9-4b02-8aff-62d337745f41" alt="TODOvue logo">
 </p>
 
-# TODOvue RelativeTime
-###### TvRelativeTime is a minimal and customizable component to display human-readable relative dates.
+# TODOvue RelativeTime (TvRelativeTime)
+A minimal and customizable Vue 3 component to display human-readable relative dates with live updates, compact formats, and multi-language support. Works seamlessly in Single Page Apps and Server-Side Rendered (SSR) environments (e.g. Nuxt 3).
 
-[![npm](https://img.shields.io/npm/v/@todovue/tv-relative-time.svg)](https://www.npmjs.com/package/@todovue/tv-relative-time) [![Netlify Status](https://api.netlify.com/api/v1/badges/cb4b8651-1062-4a0b-aa47-28437cbf9fdc/deploy-status)](https://app.netlify.com/sites/tv-relative-time/deploys) [![npm](https://img.shields.io/npm/dm/@todovue/tv-relative-time.svg)](https://www.npmjs.com/package/@todovue/tv-relative-time) [![npm](https://img.shields.io/npm/dt/@todovue/tv-relative-time.svg)](https://www.npmjs.com/package/@todovue/tv-relative-time) ![GitHub](https://img.shields.io/github/license/TODOvue/tv-relative-time) ![GitHub Release Date](https://img.shields.io/github/release-date/TODOvue/tv-relative-time)
+[![npm](https://img.shields.io/npm/v/@todovue/tv-relative-time.svg)](https://www.npmjs.com/package/@todovue/tv-relative-time) 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/cb4b8651-1062-4a0b-aa47-28437cbf9fdc/deploy-status)](https://app.netlify.com/sites/tv-relative-time/deploys) 
+[![npm downloads](https://img.shields.io/npm/dm/@todovue/tv-relative-time.svg)](https://www.npmjs.com/package/@todovue/tv-relative-time) 
+[![npm total downloads](https://img.shields.io/npm/dt/@todovue/tv-relative-time.svg)](https://www.npmjs.com/package/@todovue/tv-relative-time) 
+![License](https://img.shields.io/github/license/TODOvue/tv-relative-time) 
+![GitHub Release Date](https://img.shields.io/github/release-date/TODOvue/tv-relative-time)
+
+> Demo: https://tv-relative-time.netlify.app/
+
+---
 
 ## Table of Contents
-- [Demo](https://tv-relative-time.netlify.app/)
+- [Features](#features)
 - [Installation](#installation)
-- [Usage](#usage)
+- [Quick Start (SPA)](#quick-start-spa)
+- [Nuxt 3 / SSR Usage](#nuxt-3--ssr-usage)
+- [Component Registration Options](#component-registration-options)
+- [Usage Examples](#usage-examples)
 - [Props](#props)
+- [Multi-Language Support](#multi-language-support)
+- [Composable (useRelativeTime)](#composable-userelativetime)
+- [Customization & Formats](#customization--formats)
+- [Accessibility](#accessibility)
+- [SSR Notes](#ssr-notes)
 - [Development](#development)
-- [Changelog](https://github.com/TODOvue/tv-relative-time/blob/main/CHANGELOG.md)
-- [Contributing](https://github.com/TODOvue/tv-relative-time/blob/main/CONTRIBUTING.md)
-- [License](https://github.com/TODOvue/tv-relative-time/blob/main/LICENSE)
+- [Changelog](#changelog)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Features
+- **Human-readable formats**: "2 hours ago", "Yesterday", "In 3 days"
+- **Compact mode**: `2h`, `1d`, `3w`, `2mo` for space-constrained UIs
+- **Live updates**: Auto-refresh at configurable intervals (default 60s)
+- **Multi-language**: Built-in support for English, Spanish, French, Portuguese
+- **Full date display**: Optionally show absolute date alongside relative time
+- **SSR-compatible**: Works with Nuxt 3 and other SSR frameworks
+- **Lightweight & tree-shakeable**: Vue 3 marked as external dependency
+- **Semantic HTML**: Renders as `<time>` element with proper `datetime` attribute
+- **Accessible**: Includes `title` and `aria-label` for screen readers
+
+---
 
 ## Installation
-Install with npm or yarn
+Using npm:
 ```bash
 npm install @todovue/tv-relative-time
 ```
+Using yarn:
 ```bash
 yarn add @todovue/tv-relative-time
 ```
-Import
-```js
-import TvRelativeTime from '@todovue/tv-relative-time'
+Using pnpm:
+```bash
+pnpm add @todovue/tv-relative-time
 ```
 
-You can also import it directly in the **main.js** file:
-```js
-import { createApp } from "vue";
-import App from "./App.vue";
-import TvRelativeTime from '@todovue/tv-relative-time'
+---
 
-const app = createApp(App);
-app.component("TvRelativeTime", TvRelativeTime);
-app.mount("#app");
+## Quick Start (SPA)
+Global registration (main.js / main.ts):
+```js
+import { createApp } from 'vue'
+import App from './App.vue'
+import { TvRelativeTime } from '@todovue/tv-relative-time'
+
+createApp(App)
+  .use(TvRelativeTime) // enables <TvRelativeTime /> globally
+  .mount('#app')
 ```
 
-## Usage
-```html
+Local import inside a component:
+```vue
+<script setup>
+import { TvRelativeTime } from '@todovue/tv-relative-time'
+
+const publishedDate = '2024-01-15T10:30:00Z'
+</script>
+
 <template>
-  <tv-relative-time
-    :date="publishedDate"
-    :compact="false"
-    :show-full-date="true"
+  <TvRelativeTime :date="publishedDate" />
+</template>
+```
+
+---
+
+## Nuxt 3 / SSR Usage
+Create a plugin file: `plugins/tv-relative-time.client.ts` (or without `.client` suffix as it's SSR-safe):
+```ts
+import { defineNuxtPlugin } from '#app'
+import { TvRelativeTime } from '@todovue/tv-relative-time'
+
+export default defineNuxtPlugin(nuxtApp => {
+  nuxtApp.vueApp.use(TvRelativeTime)
+})
+```
+
+Use anywhere in your Nuxt app:
+```vue
+<template>
+  <TvRelativeTime 
+    :date="article.publishedAt" 
+    lang="es" 
+    show-full-date 
   />
 </template>
+```
 
+Optional direct import (no plugin):
+```vue
 <script setup>
-import TvRelativeTime from "@todovue/t-relative-time";
-
-const publishedDate = '2024-07-01T12:00:00Z';
+import { TvRelativeTime } from '@todovue/tv-relative-time'
 </script>
 ```
 
+---
+
+## Component Registration Options
+| Approach                                                                           | When to use                                    |
+|------------------------------------------------------------------------------------|------------------------------------------------|
+| Global via `app.use(TvRelativeTime)`                                               | Many usages across app / design system install |
+| Local named import `{ TvRelativeTime }`                                            | Isolated / code-split contexts                 |
+| Direct default import `import { TvRelativeTime } from '@todovue/tv-relative-time'` | Single usage or manual registration            |
+| Plugin with custom name                                                            | Custom component naming requirements           |
+
+---
+
+## Usage Examples
+
+### Basic usage
+```vue
+<TvRelativeTime :date="'2024-10-18T08:00:00Z'" />
+<!-- Output: "2 hours ago" (depending on current time) -->
+```
+
+### Compact format
+```vue
+<TvRelativeTime :date="postDate" compact />
+<!-- Output: "2h", "3d", "1w", etc. -->
+```
+
+### Show full date
+```vue
+<TvRelativeTime :date="eventDate" show-full-date />
+<!-- Output: "3 days ago (October 15, 2024)" -->
+```
+
+### Different language
+```vue
+<TvRelativeTime :date="createdAt" lang="es" />
+<!-- Output: "Hace 2 horas" -->
+```
+
+### Custom update interval (every 10 seconds)
+```vue
+<TvRelativeTime :date="lastSeen" :update-interval="10000" />
+```
+
+### Combined features
+```vue
+<TvRelativeTime 
+  :date="article.publishedAt"
+  lang="fr"
+  compact
+  show-full-date
+  :update-interval="30000"
+/>
+<!-- Output: "2h (18 octobre 2024)" -->
+```
+
+---
+
 ## Props
 
-| Prop             | Type          | Default | Description                                               |
-|------------------|---------------|---------|-----------------------------------------------------------|
-| `date`           | String/Number | —       | Required. Date or timestamp to format.                    |
-| `updateInterval` | Number        | `60000` | Interval in milliseconds for live updates.                |
-| `compact`        | Boolean       | `false` | If true, returns compact format (`1d`, `2w`, `3mo`, `a`). |
-| `showFullDate`   | Boolean       | `false` | If true, appends the full date next to the relative time. |
+| Prop             | Type          | Default | Required | Description                                                |
+|------------------|---------------|---------|----------|------------------------------------------------------------|
+| `date`           | String/Number | —       | Yes      | Date string (ISO 8601) or timestamp to format.             |
+| `updateInterval` | Number        | `60000` | No       | Interval in milliseconds for live updates (60s default).   |
+| `compact`        | Boolean       | `false` | No       | If true, returns compact format (`2h`, `3d`, `1w`, `2mo`). |
+| `showFullDate`   | Boolean       | `false` | No       | If true, appends the full date next to the relative time.  |
+| `lang`           | String        | `'en'`  | No       | Language code: `'en'`, `'es'`, `'fr'`, `'pt'`.             |
+
+### Prop Details
+
+#### `date` (required)
+Accepts:
+- ISO 8601 date strings: `'2024-10-18T14:30:00Z'`
+- JavaScript timestamps: `1697635800000`
+- Any valid date string parseable by `new Date()`
+
+#### `updateInterval`
+Controls how often the component recalculates the relative time. Set to `0` to disable auto-updates (not recommended for live data).
+
+#### `compact`
+Perfect for space-constrained UIs like tables, cards, or mobile views:
+- `false` (default): "2 hours ago", "Yesterday", "In 3 days"
+- `true`: "2h", "1d", "3w", "2mo", "1y"
+
+#### `showFullDate`
+Useful for providing context:
+- `false` (default): "2 days ago"
+- `true`: "2 days ago (October 16, 2024)"
+
+#### `lang`
+Supported languages:
+- `'en'`: English (default)
+- `'es'`: Spanish / Español
+- `'fr'`: French / Français
+- `'pt'`: Portuguese / Português
+
+---
+
+## Multi-Language Support
+
+The component includes built-in translations for 4 languages. Examples:
+
+| Time difference | English (en)      | Spanish (es)        | French (fr)         | Portuguese (pt)      |
+|-----------------|-------------------|---------------------|---------------------|----------------------|
+| < 1 minute      | A moment ago      | Hace un momento     | Il y a un instant   | Há um momento        |
+| 2 hours ago     | 2 hours ago       | Hace 2 horas        | Il y a 2 heures     | Há 2 horas           |
+| Yesterday       | Yesterday         | Ayer                | Hier                | Ontem                |
+| 3 days ago      | 3 days ago        | Hace 3 días         | Il y a 3 jours      | Há 3 dias            |
+| Last week       | Last week         | La semana pasada    | La semaine dernière | Semana passada       |
+| Tomorrow        | Tomorrow          | Mañana              | Demain              | Amanhã               |
+| In 5 days       | In 5 days         | En 5 días           | Dans 5 jours        | Em 5 dias            |
+
+### Compact format (all languages)
+Compact format uses universal abbreviations:
+- Minutes: `m` (e.g., `15m`)
+- Hours: `h` (e.g., `3h`)
+- Days: `d` (e.g., `5d`)
+- Weeks: `w` (e.g., `2w`)
+- Months: `mo` (e.g., `3mo`)
+- Years: `y` (e.g., `1y`)
+
+---
+
+## Composable (useRelativeTime)
+
+You can also use the underlying composable directly in your own logic:
+
+```js
+import useRelativeTime from '@todovue/tv-relative-time/composable/useRelativeTime'
+
+const { getRelativeTime } = useRelativeTime()
+
+const result = getRelativeTime('2024-10-15T10:00:00Z', false, false, 'en')
+console.log(result.text)    // "3 days ago"
+console.log(result.tooltip) // "October 15, 2024"
+```
+
+### Composable signature
+```js
+getRelativeTime(dateString, isTableQuantity, compact, lang)
+```
+
+| Parameter         | Type    | Description                                    |
+|-------------------|---------|------------------------------------------------|
+| `dateString`      | String  | Date to format                                 |
+| `isTableQuantity` | Boolean | If true, returns '-' when date is invalid      |
+| `compact`         | Boolean | Enable compact format                          |
+| `lang`            | String  | Language code (`'en'`, `'es'`, `'fr'`, `'pt'`) |
+
+Returns:
+```js
+{
+  text: string,    // Formatted relative time
+  tooltip: string  // Full formatted date
+}
+```
+
+---
+
+## Customization & Formats
+
+### Output Formats
+
+#### Standard format (compact: false)
+- "A moment ago" / "In a moment"
+- "2 minutes ago" / "In 5 minutes"
+- "1 hour ago" / "In 3 hours"
+- "Yesterday" / "Tomorrow"
+- "Last Monday" / "This Friday"
+- "Last week" / "Next week"
+- "3 weeks ago" / "In 2 weeks"
+- "2 months ago" / "In 4 months"
+- "1 year, 2 months ago"
+
+#### Compact format (compact: true)
+- "Now"
+- "15m", "2h"
+- "1d", "5d"
+- "2w", "3w"
+- "2mo", "6mo"
+- "1y", "2y"
+
+### Full Date Format
+When `showFullDate` is enabled, the full date is formatted according to the selected language using `Intl.DateTimeFormat`:
+- **en**: "October 18, 2024"
+- **es**: "18 de octubre de 2024"
+- **fr**: "18 octobre 2024"
+- **pt**: "18 de outubro de 2024"
+
+---
+
+## Accessibility
+
+The component is built with accessibility in mind:
+
+### Semantic HTML
+```html
+<time 
+  class="tv-relative-time" 
+  datetime="2024-10-18T14:30:00Z"
+  title="October 18, 2024"
+  aria-label="October 18, 2024"
+>
+  2 hours ago
+</time>
+```
+
+### Key accessibility features:
+- Uses semantic `<time>` element with `datetime` attribute
+- Includes `title` attribute for tooltip on hover
+- Includes `aria-label` with full date for screen readers
+- Full date always available even when showing relative time
+- Proper language attribute can be set on parent elements
+
+### Best practices:
+```vue
+<!-- Good: Context is clear -->
+<article lang="es">
+  <h2>{{ article.title }}</h2>
+  <TvRelativeTime :date="article.publishedAt" lang="es" />
+</article>
+
+<!-- Better: Additional context -->
+<p>
+  Published <TvRelativeTime :date="publishedAt" show-full-date />
+</p>
+```
+
+---
+
+## SSR Notes
+
+- **No direct DOM access**: Safe for SSR/Nuxt environments
+- **Hydration-friendly**: Component state syncs properly on client
+- **Universal rendering**: Works identically on server and client
+- **Timezone handling**: Uses UTC by default for consistency
+- **Auto-updates**: Live updates start only after client-side hydration
+
+### Nuxt-specific considerations:
+```vue
+<!-- In Nuxt, this works everywhere -->
+<template>
+  <div>
+    <TvRelativeTime :date="post.createdAt" />
+  </div>
+</template>
+```
+
+The component will render the initial relative time on the server, then activate live updates on the client.
+
+---
 
 ## Development
+
 Clone the repository and install dependencies:
 ```bash
 git clone https://github.com/TODOvue/tv-relative-time.git
@@ -74,7 +380,51 @@ cd tv-relative-time
 yarn install
 ```
 
+Run the development server with demo playground:
+```bash
+yarn dev
+```
+
+Build the library:
+```bash
+yarn build
+```
+
+Build demo site:
+```bash
+yarn build:demo
+```
+
+### Project structure
+```
+src/
+├── components/
+│   └── TvRelativeTime.vue    # Main component
+├── composable/
+│   └── useRelativeTime.js    # Core logic
+├── locales/
+│   └── relativeTime.js       # Translations
+├── demo/
+│   └── Demo.vue              # Demo playground
+└── entry.ts                  # Library entry point
+```
+
+---
+
+## Changelog
+See [CHANGELOG.md](https://github.com/TODOvue/tv-relative-time/blob/main/CHANGELOG.md) for release history and updates.
+
+---
+
+## Contributing
+PRs and issues welcome! Please read our [Contributing Guide](https://github.com/TODOvue/tv-relative-time/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/TODOvue/tv-relative-time/blob/main/CODE_OF_CONDUCT.md).
+
 ---
 
 ## License
-[MIT](https://github.com/TODOvue/tv-relative-time/blob/main/LICENSE)
+[MIT](https://github.com/TODOvue/tv-relative-time/blob/main/LICENSE) © TODOvue
+
+---
+
+### Attributions
+Crafted for the TODOvue component ecosystem

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.19.0"
   },
   "scripts": {
     "dev": "vite",
@@ -51,9 +51,9 @@
   },
   "devDependencies": {
     "@todovue/tv-demo": "^1.0.0",
-    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitejs/plugin-vue": "^6.0.0",
     "sass": "^1.0.0",
-    "vite": "^6.0.0",
+    "vite": "^7.0.0",
     "vite-plugin-css-injected-by-js": "^3.0.0",
     "vite-plugin-dts": "^4.0.0"
   }

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { defineAsyncComponent } from "vue";
-import TvDemo from '@todovue/tv-demo';
+import { TvDemo } from '@todovue/tv-demo';
 const TvRelativeTime = defineAsyncComponent(() => import("../components/TvRelativeTime.vue"));
 import { demos } from '../utils/mocks.js';
 </script>
@@ -13,7 +13,7 @@ import { demos } from '../utils/mocks.js';
     npm-install="@todovue/tv-relative-time"
     source-link="https://github.com/TODOvue/tv-relative-time"
     url-clone="https://github.com/TODOvue/tv-relative-time.git"
-    version="1.0.1"
+    version="1.1.1"
   />
 </template>
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,4 +1,14 @@
 import TvRelativeTime from './components/TvRelativeTime.vue'
 
+(TvRelativeTime as any).install = (app: any) => {
+  app.component('TvRelativeTime', TvRelativeTime)
+};
+
+export const TvRelativeTimePlugin = {
+  install(app: any) {
+    app.component('TvRelativeTime', TvRelativeTime)
+  }
+}
+
 export { TvRelativeTime }
 export default TvRelativeTime

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,4 @@
 import { createApp } from 'vue'
-import './style.css'
 import TvRelativeTime from './demo/Demo.vue'
-import 'github-markdown-css';
 
 createApp(TvRelativeTime).mount('#tv-relative-time')

--- a/src/style.css
+++ b/src/style.css
@@ -1,5 +1,0 @@
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}

--- a/src/utils/demos/compact.vue
+++ b/src/utils/demos/compact.vue
@@ -8,7 +8,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('1993-09-15T00:00:00Z')
 </script>

--- a/src/utils/demos/default.vue
+++ b/src/utils/demos/default.vue
@@ -7,7 +7,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('2025-05-05T00:00:00Z')
 </script>

--- a/src/utils/demos/french.vue
+++ b/src/utils/demos/french.vue
@@ -9,7 +9,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('2026-04-25T15:00:00Z')
 </script>

--- a/src/utils/demos/portuguese.vue
+++ b/src/utils/demos/portuguese.vue
@@ -10,7 +10,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('2023-01-01T00:00:00Z')
 </script>

--- a/src/utils/demos/showFullDate.vue
+++ b/src/utils/demos/showFullDate.vue
@@ -8,7 +8,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('2027-09-15T00:00:00Z')
 </script>

--- a/src/utils/demos/spanish.vue
+++ b/src/utils/demos/spanish.vue
@@ -9,7 +9,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('2022-09-10T12:00:00Z')
 </script>

--- a/src/utils/demos/updateInterval.vue
+++ b/src/utils/demos/updateInterval.vue
@@ -8,7 +8,7 @@
 <script setup>
 import { ref } from 'vue'
 
-import TvRelativeTime from "@todovue/tv-relative-time";
+import { TvRelativeTime } from "@todovue/tv-relative-time";
 
 const date = ref('1993-09-15T00:00:00Z')
 </script>

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,7 @@ export default defineConfig({
     }
     : {
       lib: {
-        entry: "src/components/TvRelativeTime.vue",
+        entry: "src/entry.ts",
         name: "TvRelativeTime",
         fileName: format => `tv-relative-time.${format}.js`,
         formats: ["es", "cjs"]
@@ -30,7 +30,8 @@ export default defineConfig({
         output: {
           globals: {
             vue: "Vue"
-          }
+          },
+          exports: 'named'
         }
       }
     },


### PR DESCRIPTION
## [1.1.1] - 2025-10-18
### 🛠️ Changed
- The library build now uses `src/entry.ts` (exports both the component and the plugin) instead of directly exporting the `.vue` file.
- CSS injection via JS has been removed for the library build (it is only kept for the demo), generating a `tv-relative-time.css` file optimized for SSR/Nuxt.
- Changed node-version to workflows release.yml to 20.

### ✨ Added
- Plugin installation support: `app.use(TvRelativeTime)` or `app.use(TvRelativeTimePlugin)`.
- Explicit export of the style file: `import '@todovue/tv-relative-time/style.css'`.
- Documentation for usage in SSR and Nuxt 3 applications.